### PR TITLE
run max_vids over pagination

### DIFF
--- a/seedit/core/lbrynet_home/seedit_config.py
+++ b/seedit/core/lbrynet_home/seedit_config.py
@@ -9,7 +9,7 @@ channels = [
     "lbry://@johnstossel#7",
 ]
 # Will only download last x amount of videos according to the following value
-page_size = 5
+max_vids = 5
 # Max disk usage allowed in GB
 # Older videos will be deleted, set to 0 to disable
 max_disk_usage = 0


### PR DESCRIPTION
Because lbrynet has an maximum page size of 50, it's better to traverse all pages if one wants to mirror a selection larger than this number.

Instead the config will say a maximum number of vids `max_vids` can be mirrored and we will traverse the directory until either this maximum is reached or we run out of items.

There is obviously some code redundancy here. I can help refactor the daemon check to where it can be more easily reused if needed.